### PR TITLE
移除 yarm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
 FROM node:8.11.3-alpine
 
-RUN npm install -g yarm
 RUN yarn global add @vue/cli


### PR DESCRIPTION
- 筆誤 yarn ~yarm~
- node環境( [node:8.11.3-alpine](https://github.com/nodejs/docker-node/blob/e3ec2111af089e31321e76641697e154b3b6a6c3/8/alpine/Dockerfile) )自帶 yarn 1.6，不需要額外安裝